### PR TITLE
Disallow console.log;

### DIFF
--- a/rules/errors.js
+++ b/rules/errors.js
@@ -7,7 +7,7 @@ module.exports = {
         // disallow assignment in conditional expressions
         "no-cond-assign": [2, "always"],
         // disallow use of console
-        "no-console": 0,
+        "no-console": ["error", { allow: ["warn", "error"] }],
         // disallow use of constant expressions in conditions
         "no-constant-condition": 1,
         // disallow control characters in regular expressions


### PR DESCRIPTION
This change suppresses console.log, but still allows console.warn and console.error to be used. This can be [overridden when necessary](https://eslint.org/docs/rules/no-console#when-not-to-use-it).

**Reference:**
[disallow the use of console (no-console)](https://eslint.org/docs/rules/no-console)