### PR TITLE
Disallow consecutive empty lines

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -61,8 +61,8 @@ module.exports = {
         "no-lonely-if": 0,
         // disallow mixed spaces and tabs for indentation
         "no-mixed-spaces-and-tabs": 2,
-        // disallow multiple empty lines and only one newline at the end
-        "no-multiple-empty-lines": [2, { "max": 2, "maxEOF": 1 }],
+        // disallow consecutive empty lines
+        "no-multiple-empty-lines": [2, { "max": 1 }],
         // disallow nested ternary expressions
         "no-nested-ternary": 2,
         // disallow use of the Object constructor


### PR DESCRIPTION
Follow up PR to discussion here: https://github.com/eBay/eslint-config-ebay/issues/10

Updates `no-multiple-empty-lines` rule to a max of 1 empty line across all cases.